### PR TITLE
PR-118: add pathing metadata; fix metatype bug

### DIFF
--- a/src/libpython_clj/require.clj
+++ b/src/libpython_clj/require.clj
@@ -127,7 +127,9 @@
                                   " to something without periods."))))        
         (intern
          (symbol (str *ns*))
-         (symbol import-name)
+         (with-meta (symbol import-name)
+           {:file (metadata/find-file pyobj)
+            :line 1})
          pyobj)))
     
     (when (or (not existing-py-ns?) reload?)

--- a/test/libpython_clj/require_python_test.clj
+++ b/test/libpython_clj/require_python_test.clj
@@ -114,7 +114,35 @@
 
   (is (set? (datafy (python/frozenset [1 2 3])))))
 
-
-
 (deftest import-python-test
   (is (= :ok (libpython-clj.require/import-python))))
+
+(require-python '[socket :bind-ns true])
+(require-python 'socket.SocketIO)
+(deftest metadata-test
+  (testing "metadata generation"
+    ;; module meta
+    (let [{line :line file :file} (meta #'socket)]
+      (is (= 1 line)
+          "Modules have line numbers")
+      (is (string? file)
+          "Modules have file paths"))
+    ;; class meta
+    (let [{line :line file :file} (meta #'socket/SocketIO)]
+      (is (int? line)
+          "Classes have line numbers")
+      (is (string? file)
+          "Classes have file paths"))
+    ;; function meta
+    (let [{line :line file :file} (meta #'socket/_intenum_converter)]
+      (is (int? line)
+          "Functions have line numbers")
+      (is (string? file)
+          "Functions have file paths"))
+    ;; method meta
+    (let [{line :line file :file} (meta #'socket.SocketIO/readable)]
+      (is (int? line)
+          "Methods have line numbers")
+      (is (string? file)
+          "Methods have file paths"))))
+


### PR DESCRIPTION
Closes: https://github.com/clj-python/libpython-clj/issues/116

Editors that support "jump to source" can now jump to source using the metadata of Python functions, classes, modules, and methods instantiated via `require-python`.

Additionally, discovered a bug that prevented `socket.SocketIO` from being interned with `require-python`, since it is neither a Python module nor Python `type` (it is an `abc.meta`).  Put a generic exception wrapper with handling for metatypes.  

![jumpToSource](https://user-images.githubusercontent.com/10394611/92189455-b02e0880-ee2c-11ea-8630-35ca4d8c803b.gif)
