### PR TITLE
ISSUE-129: bad docstring on run-simple-string

### DIFF
--- a/src/libpython_clj/python.clj
+++ b/src/libpython_clj/python.clj
@@ -163,7 +163,7 @@
 
 (defn run-simple-string
   "Run a string expression returning a map of
-  {:globals :locals :result}.
+  {:globals :locals}.
   This uses the global __main__ dict under the covers so it matches the behavior
   of the cpython implementation with the exception of returning the various maps
   used.


### PR DESCRIPTION
Closes: https://github.com/clj-python/libpython-clj/issues/129

Docstring on `run-simple-string` gives the impression a `:result` will be returned.  On examining the code, it's clear that no meaningful result will be returned in `:result`, and so the documentation should be amended to reflect that.  

