### PR TITLE
Fix set-item! docstring

### DIFF
--- a/src/libpython_clj2/python.clj
+++ b/src/libpython_clj2/python.clj
@@ -232,7 +232,7 @@ user> (py/py. np linspace 2 3 :num 10)
 
 
 (defn set-item!
-  "Get an item from a python object using  __setitem__"
+  "Set an item on a python object using  __setitem__"
   [pyobj item-name item-val]
   (with-gil (py-proto/set-item! pyobj item-name item-val))
   pyobj)


### PR DESCRIPTION
Looks like the `set-item!` docstring was copied from `get-item` without changing its operation description.