### PR TITLE
Autocasting args of `py{*}` family of macros to python via `py/->python`

### DIFF
--- a/src/libpython_clj2/python.clj
+++ b/src/libpython_clj2/python.clj
@@ -663,7 +663,7 @@ nil
 
          :else ;; assumed to be method invocation
 
-         (list* (into (vector #'py. x instance-member) args))))
+         (list* (into (vector #'py. x instance-member) (map (fn [arg] `(#'->python ~arg))  args)))))
      (handle-pydotdot x (list form))))
   ([x form & more]
    (apply handle-pydotdot (handle-pydotdot x form) more)))

--- a/test/libpython_clj2/python_test.clj
+++ b/test/libpython_clj2/python_test.clj
@@ -422,6 +422,15 @@ class Foo:
     (is (= [5 2]
            (py/->jvm (py/get-attr pp "shape"))))))
 
+(deftest null-pointer-on-python-iterator
+  (py/run-simple-string "
+class Thing:
+    def __call__(this, data):
+        return {a: b for a, b in data.items()}")
+  (let [main (py/import-module "__main__")
+        thing (py/get-attr main "Thing")]
+    (py.. (thing) (__call__  {}))))
+
 
 (comment
   (require '[libpython-clj.require :refer [require-python]])


### PR DESCRIPTION
Autocasting args of `py{*}` family of macros to python via `py/->python`