### PR TITLE
added functions which print classpath and java args from aliases

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -2,7 +2,8 @@
  :deps {org.clojure/clojure  {:mvn/version "1.11.1" :scope "provided"}
         cnuernber/dtype-next {:mvn/version "9.032"}
         net.java.dev.jna/jna {:mvn/version "5.12.1"}
-        org.clojure/data.json  {:mvn/version "1.0.0"}}
+        org.clojure/data.json  {:mvn/version "1.0.0"}
+        io.github.clojure/tools.build {:git/tag "v0.8.3" :git/sha "0d20256"}}
 
  :aliases {:dev
            {:extra-deps {criterium/criterium {:mvn/version"0.4.5"}
@@ -70,6 +71,6 @@
            {:replace-deps {slipset/deps-deploy {:mvn/version "0.1.5"}}
             :exec-fn deps-deploy.deps-deploy/deploy
             :exec-args {:installer :local
-                        :artifact "target/libpython-clj.jar"}}
+                        :artifact "target/libpython-clj.jar"}}}}
 
-           }}
+           

--- a/src/libpython_clj2/embedded.clj
+++ b/src/libpython_clj2/embedded.clj
@@ -9,7 +9,9 @@ clojure -SPath '{:deps {nrepl/nrepl {:mvn/version \"0.8.3\"} cider/cider-nrepl {
   (:require [libpython-clj2.python.ffi :as py-ffi]
             [nrepl.server :as server]
             [nrepl.cmdline :as cmdline]
-            [clojure.tools.logging :as log]))
+            [clojure.tools.logging :as log]
+            [clojure.tools.build.api :as b]
+            [clojure.string :as str]))
 
 
 (defn initialize!
@@ -66,3 +68,20 @@ clojure -SPath '{:deps {nrepl/nrepl {:mvn/version \"0.8.3\"} cider/cider-nrepl {
          (.wait ^Object #'repl-server*))))
    (:port @repl-server*))
   ([] (start-repl! nil)))
+
+
+(defn print-jvm-args
+  "Resolves the given deps.end aliases to jvm-args and prints them"
+  [aliases]
+  (let [basis (b/create-basis {:aliases (map keyword aliases)})
+        jvm-args
+        (str/join " " (:jvm-opts (:resolve-args basis)))]
+    (println jvm-args)))
+
+(defn print-classpath
+  "Resolves the given deps.end aliases to classpath and prints it"
+  [aliases]
+  (let [basis (b/create-basis {:aliases (map keyword aliases)})
+        cp
+        (->> basis :classpath-roots (str/join ":"))]
+    (println cp)))


### PR DESCRIPTION
see here for discussion:

https://clojurians.zulipchat.com/#narrow/stream/215609-libpython-clj-dev/topic/bootstrap.20libpython-clj.20embedded

The new functions are meant to be used  by `clojurebridge` to  find out which java args (an later classpath) the JVM to be started needs.