### PR TITLE
add 2 Init lifecycle hooks

### DIFF
--- a/src/libpython_clj2/python.clj
+++ b/src/libpython_clj2/python.clj
@@ -42,8 +42,6 @@ user> (py/py. np linspace 2 3 :num 10)
 
 (set! *warn-on-reflection* true)
 
-(defn- no-op [])
-
 (defn initialize!
     "Initialize the python library.  If library path is not provided, then the system
   attempts to execute a simple python program and have python return system info.
@@ -115,7 +113,7 @@ user> (py/py. np linspace 2 3 :num 10)
     (let [python-edn-opts (-> (try (slurp "python.edn")
                                    (catch java.io.FileNotFoundException _ "{}"))
                               clojure.edn/read-string)
-          _ ((requiring-resolve (get python-edn-opts :pre-initialize-fn 'libpython-clj2.python/no-op)))
+          _ (some-> python-edn-opts :pre-initialize-fn requiring-resolve (apply []))
           options (merge python-edn-opts options)
           info (py-info/detect-startup-info options)
           _ (log/infof "Startup info %s" info)
@@ -151,10 +149,9 @@ user> (py/py. np linspace 2 3 :num 10)
             (io-redirect/redirect-io!))
           (finally
             (py-ffi/unlock-gil gilstate))))
-      ((requiring-resolve (get python-edn-opts :post-initialize-fn 'libpython-clj2.python/no-op)))
+      (some-> python-edn-opts :post-initialize-fn requiring-resolve (apply []))
       :ok)
     :already-initialized))
-
 
 (defmacro stack-resource-context
   "Create a stack-based resource context.  All python objects allocated within this

--- a/src/libpython_clj2/python.clj
+++ b/src/libpython_clj2/python.clj
@@ -42,7 +42,7 @@ user> (py/py. np linspace 2 3 :num 10)
 
 (set! *warn-on-reflection* true)
 
-
+(defn- no-op [])
 
 (defn initialize!
     "Initialize the python library.  If library path is not provided, then the system
@@ -97,6 +97,7 @@ user> (py/py. np linspace 2 3 :num 10)
     (let [python-edn-opts (-> (try (slurp "python.edn")
                                    (catch java.io.FileNotFoundException _ "{}"))
                               clojure.edn/read-string)
+          _ ((requiring-resolve (get python-edn-opts :pre-initialize-fn 'libpython-clj2.python/no-op)))
           options (merge python-edn-opts options)
           info (py-info/detect-startup-info options)
           _ (log/infof "Startup info %s" info)
@@ -132,6 +133,7 @@ user> (py/py. np linspace 2 3 :num 10)
             (io-redirect/redirect-io!))
           (finally
             (py-ffi/unlock-gil gilstate))))
+      ((requiring-resolve (get python-edn-opts :post-initialize-fn 'libpython-clj2.python/no-op)))
       :ok)
     :already-initialized))
 

--- a/src/libpython_clj2/python.clj
+++ b/src/libpython_clj2/python.clj
@@ -64,6 +64,24 @@ user> (py/py. np linspace 2 3 :num 10)
   {:python-executable   \"env/bin/python\"}
   ```
 
+  Additionaly the file can contain two keys which can can refer to custom hooks
+  to run code just before and just after python is initialised.
+  Typical use case for this is to setup / verify the python virtual enviornment
+  to be used.
+
+  ```
+  :pre-initialize-fn my-ns/my-venv-setup-fn!
+  :post-initialize-fn my-ns/my-venv-validate-fn!
+
+  ```
+
+  A :pre-initialize-fn could for example shell out and setup a python
+  virtual enviornment.
+
+  The :post-initialize-fn can use all functions from ns `libpython-clj2.python`
+  as libpython-clj is initialised alreday andc ould for example be used to validate
+  that later needed libraries can be loaded via calling `import-module`.
+
   The file MUST be named `python.edn` and be in the root of the classpath.
   With a `python.edn` file in place, the `initialize!` function may be called
   with no arguments and the options will be read from the file. If arguments are 


### PR DESCRIPTION
Add 2 post and pre initialize hooks, see here:

https://clojurians.zulipchat.com/#narrow/stream/215609-libpython-clj-dev/topic/auto-setup.20of.20venvs.20.3F/near/313150680

I tried these to setup / validate a venv and find this rather convenient.
If the 2 new keys are not present in `python.edn` nothing happens
