### PR TITLE
Extend ci coverage to ms-win/macos, fix ns issue in test for py>3.10

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,52 @@
+name: test
+
+on:
+  push:
+    branches:
+      - master
+    paths-ignore:
+      - '**/README.md'
+      - '**/CHANGELOG.md'
+  pull_request:
+
+jobs:
+  unit-test:
+    runs-on: ${{matrix.os}}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, ubuntu-latest, windows-latest]
+        jdk: [8, 17, 19]
+        python-version: ["3.9", "3.11"]
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up JDK ${{ matrix.jdk }}
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.jdk }}
+
+      - name: Install Clojure
+        uses: DeLaGuardo/setup-clojure@11.0
+        with:
+          cli: 1.11.1.1347
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install numpy
+
+      - name: Run tests (jdk<17)
+        if: ${{ matrix.jdk < 17 }}
+        run: |
+          clojure -M:test
+      - name: Run tests (jdk>=17)
+        if: ${{ matrix.jdk >= 17 }}
+        run: |
+          clojure -M:jdk-${{matrix.jdk}}:test

--- a/test/libpython_clj2/python_test.clj
+++ b/test/libpython_clj2/python_test.clj
@@ -365,7 +365,7 @@ class Foo:
         bridged-dict (py/as-python {"a" 1 "b" 2})
         bridged-iter (py/as-python (repeat 5 1))
         bridged-list (py/as-python (vec (range 10)))
-        pycol (py/import-module "collections")
+        pycol (py/import-module "collections.abc")
         mapping-type (py/get-attr pycol "Mapping")
         iter-type (py/get-attr pycol "Iterable")
         sequence-type (py/get-attr pycol "Sequence")]


### PR DESCRIPTION
Hi,

can you please consider patch to migrate CI testing to GH extending support to all mainstream architectures, most java versions and key python releases. It addresses #248 .

It also fixes a break on the test suite due to a removal of a deprecated package path in python versions >= 3.10 as explained on the issue.

The coverage includes macos, ubuntu and win latest versions,  java 8, 17 and 19, clojure 1.11, and python versions 3.9 (testing backward compatibility for the test fix) and 3.11 (latest python).

The windows test suite will fail pending merging of #247.

I assume if we are to go ahead with this we can also rm the travis.yml.

Thanks 