### PR TITLE
Handle conversion of generic-alias and union-type types in ->jvm

### DIFF
--- a/test/libpython_clj2/require_python_test.clj
+++ b/test/libpython_clj2/require_python_test.clj
@@ -146,3 +146,12 @@
           "Methods have line numbers")
       (is (string? file)
           "Methods have file paths"))))
+
+(deftest convert-types
+  (let [typing-module (py/import-module "typing")]
+    (testing "convert generic alias type to JVM"
+      (-> (py/py. typing-module GenericAlias list str)
+          py/->jvm
+          :type
+          (= :generic-alias)
+          is))))


### PR DESCRIPTION
See issue #250.

Some python types (in particular `GenericAlias` and `Union`) cannot be handled by the default `->jvm` handler.